### PR TITLE
Remove depreciated Java option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 android.useAndroidX=true
 org.gradle.daemon=true
 org.gradle.configureondemand=true
-org.gradle.jvmargs=-XX:MaxPermSize=512m
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Gradle 8 https://github.com/machiav3lli/DerDieDas/blob/2.2.0/gradle/wrapper/gradle-wrapper.properties#L4 needs Java 17

Java17 does not use this https://gitlab.com/fdroid/fdroiddata/-/jobs/5065797074#L361

